### PR TITLE
Forecasts limited to registered sensors

### DIFF
--- a/flexmeasures_openweathermap/utils/locating.py
+++ b/flexmeasures_openweathermap/utils/locating.py
@@ -99,9 +99,4 @@ def find_weather_sensor_by_location_or_fail(
             raise Exception(
                 f"[FLEXMEASURES-OWM] No sufficiently close weather sensor found (within {max_degree_difference_for_nearest_weather_sensor} {flexmeasures_inflection.pluralize('degree', max_degree_difference_for_nearest_weather_sensor)} distance) for measuring {sensor_name}! We're looking for: {location}, closest available: ({weather_station.location})"
             )
-    else:
-        raise Exception(
-            "[FLEXMEASURES-OWM] No weather sensor set up yet for measuring %s. Try the register-weather-sensor CLI task."
-            % sensor_name
-        )
     return weather_sensor

--- a/flexmeasures_openweathermap/utils/owm.py
+++ b/flexmeasures_openweathermap/utils/owm.py
@@ -103,8 +103,8 @@ def save_forecasts_in_db(
                 datetime.fromtimestamp(fc["dt"], get_timezone())
             )
             click.echo(f"[FLEXMEASURES-OWM] Processing forecast for {fc_datetime} ...")
+            data_source = get_or_create_owm_data_source()
             for sensor_specs in mapping:
-                data_source = get_or_create_owm_data_source()
                 sensor_name = str(sensor_specs["fm_sensor_name"])
                 owm_response_label = sensor_specs["owm_sensor_name"]
                 if owm_response_label in fc:
@@ -192,7 +192,7 @@ def get_weather_sensor(
         weather_sensor is not None
         and weather_sensor.event_resolution != sensor_specs["event_resolution"]
     ):
-        current_app.logger.warning(
+        raise Exception(
             f"[FLEXMEASURES-OWM] The weather sensor found for {sensor_name} has an unfitting event resolution (should be {sensor_specs['event_resolution']}, but is {weather_sensor.event_resolution}."
         )
     return weather_sensor

--- a/flexmeasures_openweathermap/utils/owm.py
+++ b/flexmeasures_openweathermap/utils/owm.py
@@ -20,6 +20,9 @@ from .modeling import (
 )
 from .radiating import compute_irradiance
 
+    
+API_VERSION = "3.0"
+
 
 def get_supported_sensor_spec(name: str) -> Optional[dict]:
     """
@@ -49,8 +52,11 @@ def call_openweatherapi(
     See https://openweathermap.org/api/one-call-api for docs.
     Note that the first forecast is about the current hour.
     """
+    check_openweathermap_version(API_VERSION)
     query_str = f"lat={location[0]}&lon={location[1]}&units=metric&exclude=minutely,daily,alerts&appid={api_key}"
-    res = requests.get(f"http://api.openweathermap.org/data/2.5/onecall?{query_str}")
+    res = requests.get(
+        f"http://api.openweathermap.org/data/{API_VERSION}/onecall?{query_str}"
+    )
     assert (
         res.status_code == 200
     ), f"OpenWeatherMap returned status code {res.status_code}: {res.text}"
@@ -211,3 +217,11 @@ def save_forecasts_as_json(
         )
         with open(forecasts_file, "w") as outfile:
             json.dump(forecasts, outfile)
+
+
+def check_openweathermap_version(api_version: str):
+    supported_versions = ["2.5", "3.0"]
+    if api_version not in supported_versions:
+        current_app.logger.warning(
+            f"This plugin may not be fully compatible with OpenWeatherMap API version {api_version}. We tested with versions {supported_versions}"
+        )


### PR DESCRIPTION
Previously, our focus was on `mapping` all the available sensors, but this approach restricted us to obtaining forecasts for just one or two sensors. In this pull request (PR), I've implemented a sensor check. This means that if a sensor is not registered, it will be disregarded during the forecasting process.