### PR TITLE
Downgrade fakeredis version

### DIFF
--- a/requirements/test.in
+++ b/requirements/test.in
@@ -5,6 +5,6 @@ pytest-flask
 pytest-sugar
 pytest-cov
 # lets tests run successfully in containers
-fakeredis
+fakeredis==2.16.0
 # required with fakeredis, maybe because we use rq
 lupa


### PR DESCRIPTION
By default, we were installing the latest version `2.17.01 and because of that we had some dependencies issue. I have downgraded it to `2.16.0` version which resolve this issue #14.


closes #14.