### PR TITLE
feat: Add setting for minimal degrees search distance for weather station

### DIFF
--- a/flexmeasures_openweathermap/__init__.py
+++ b/flexmeasures_openweathermap/__init__.py
@@ -29,7 +29,7 @@ DEFAULT_FILE_PATH_LOCATION = "weather-forecasts"
 DEFAULT_DATA_SOURCE_NAME = "OpenWeatherMap"
 DEFAULT_WEATHER_STATION_NAME = "weather station (created by FM-OWM)"
 WEATHER_STATION_TYPE_NAME = "weather station"
-DEFAULT_MINIMAL_WEATHER_STATIONS = 2
+DEFAULT_MINIMAL_DISTANCE_DEGREE = 2
 
 __version__ = "0.1"
 __settings__ = {
@@ -49,8 +49,8 @@ __settings__ = {
         description=f"Name of the weather station asset, defaults to '{DEFAULT_WEATHER_STATION_NAME}'",
         level="debug",
     ),
-    "MINIMAL_WEATHER_STATIONS": dict(
-        descripion=f"Number of the closest weather stations to the location, defaults to '{DEFAULT_MINIMAL_WEATHER_STATIONS}'",
+    "MINIMAL_DISTANCE_DEGREE": dict(
+        descripion=f"Number of the minimum distance degree for weather station, defaults to '{DEFAULT_MINIMAL_DISTANCE_DEGREE}'",
         level="debug",
     ),
 }

--- a/flexmeasures_openweathermap/__init__.py
+++ b/flexmeasures_openweathermap/__init__.py
@@ -29,7 +29,7 @@ DEFAULT_FILE_PATH_LOCATION = "weather-forecasts"
 DEFAULT_DATA_SOURCE_NAME = "OpenWeatherMap"
 DEFAULT_WEATHER_STATION_NAME = "weather station (created by FM-OWM)"
 WEATHER_STATION_TYPE_NAME = "weather station"
-DEFAULT_MINIMAL_DISTANCE_DEGREE = 2
+DEFAULT_MAXIMAL_DEGREE_LOCATION_DISTANCE = 1
 
 __version__ = "0.1"
 __settings__ = {
@@ -49,8 +49,8 @@ __settings__ = {
         description=f"Name of the weather station asset, defaults to '{DEFAULT_WEATHER_STATION_NAME}'",
         level="debug",
     ),
-    "MINIMAL_DISTANCE_DEGREE": dict(
-        descripion=f"Number of the minimum distance degree for weather station, defaults to '{DEFAULT_MINIMAL_DISTANCE_DEGREE}'",
+    "OPENWEATHERMAP_MAXIMAL_DEGREE_LOCATION_DISTANCE": dict(
+        descripion=f"Maximum distance (in degrees latitude & longitude) for weather stations from forecast location, defaults to {DEFAULT_MAXIMAL_DEGREE_LOCATION_DISTANCE}",
         level="debug",
     ),
 }

--- a/flexmeasures_openweathermap/__init__.py
+++ b/flexmeasures_openweathermap/__init__.py
@@ -29,7 +29,7 @@ DEFAULT_FILE_PATH_LOCATION = "weather-forecasts"
 DEFAULT_DATA_SOURCE_NAME = "OpenWeatherMap"
 DEFAULT_WEATHER_STATION_NAME = "weather station (created by FM-OWM)"
 WEATHER_STATION_TYPE_NAME = "weather station"
-DEFAULT_DEGREE_DIFFERENCE = 2
+DEFAULT_MINIMAL_WEATHER_STATIONS = 2
 
 __version__ = "0.1"
 __settings__ = {
@@ -50,7 +50,7 @@ __settings__ = {
         level="debug",
     ),
     "MINIMAL_WEATHER_STATIONS": dict(
-        descripion=f"Number of the closest weather stations to the location, defaults to '{DEFAULT_DEGREE_DIFFERENCE}'",
+        descripion=f"Number of the closest weather stations to the location, defaults to '{DEFAULT_MINIMAL_WEATHER_STATIONS}'",
         level="debug",
     ),
 }

--- a/flexmeasures_openweathermap/__init__.py
+++ b/flexmeasures_openweathermap/__init__.py
@@ -29,6 +29,7 @@ DEFAULT_FILE_PATH_LOCATION = "weather-forecasts"
 DEFAULT_DATA_SOURCE_NAME = "OpenWeatherMap"
 DEFAULT_WEATHER_STATION_NAME = "weather station (created by FM-OWM)"
 WEATHER_STATION_TYPE_NAME = "weather station"
+DEFAULT_DEGREE_DIFFERENCE = 2
 
 __version__ = "0.1"
 __settings__ = {
@@ -46,6 +47,10 @@ __settings__ = {
     ),
     "WEATHER_STATION_NAME": dict(
         description=f"Name of the weather station asset, defaults to '{DEFAULT_WEATHER_STATION_NAME}'",
+        level="debug",
+    ),
+    "MINIMAL_WEATHER_STATIONS": dict(
+        descripion=f"Number of the closest weather stations to the location, defaults to '{DEFAULT_DEGREE_DIFFERENCE}'",
         level="debug",
     ),
 }

--- a/flexmeasures_openweathermap/utils/owm.py
+++ b/flexmeasures_openweathermap/utils/owm.py
@@ -14,7 +14,7 @@ from flexmeasures.utils.time_utils import as_server_time, get_timezone, server_n
 from flexmeasures.data.models.time_series import Sensor, TimedBelief
 from flexmeasures.data.utils import save_to_db
 
-from flexmeasures_openweathermap import DEFAULT_MINIMAL_DISTANCE_DEGREE
+from flexmeasures_openweathermap import DEFAULT_MAXIMAL_DEGREE_LOCATION_DISTANCE
 from .locating import find_weather_sensor_by_location
 from ..sensor_specs import mapping
 from .modeling import (
@@ -81,7 +81,8 @@ def save_forecasts_in_db(
     click.echo("[FLEXMEASURES-OWM] Latitude, Longitude")
     click.echo("[FLEXMEASURES-OWM] -----------------------")
     max_degree_difference_for_nearest_weather_sensor = current_app.config.get(
-        "MINIMAL_DISTANCE_DEGREE", DEFAULT_MINIMAL_DISTANCE_DEGREE
+        "OPENWEATHERMAP_MAXIMAL_DEGREE_LOCATION_DISTANCE",
+        DEFAULT_MAXIMAL_DEGREE_LOCATION_DISTANCE,
     )
     for location in locations:
         click.echo("[FLEXMEASURES] %s, %s" % location)

--- a/flexmeasures_openweathermap/utils/owm.py
+++ b/flexmeasures_openweathermap/utils/owm.py
@@ -12,7 +12,7 @@ from flexmeasures.utils.time_utils import as_server_time, get_timezone, server_n
 from flexmeasures.data.models.time_series import Sensor, TimedBelief
 from flexmeasures.data.utils import save_to_db
 
-from flexmeasures_openweathermap import DEFAULT_MINIMAL_WEATHER_STATIONS
+from flexmeasures_openweathermap import DEFAULT_MINIMAL_DISTANCE_DEGREE
 
 from .locating import find_weather_sensor_by_location_or_fail
 from ..sensor_specs import mapping
@@ -80,7 +80,7 @@ def save_forecasts_in_db(
     click.echo("[FLEXMEASURES-OWM] Latitude, Longitude")
     click.echo("[FLEXMEASURES-OWM] -----------------------")
     max_degree_difference_for_nearest_weather_sensor = current_app.config.get(
-        "MINIMAL_WEATHER_STATIONS", DEFAULT_MINIMAL_WEATHER_STATIONS
+        "MINIMAL_DISTANCE_DEGREE", DEFAULT_MINIMAL_DISTANCE_DEGREE
     )
     for location in locations:
         click.echo("[FLEXMEASURES] %s, %s" % location)

--- a/flexmeasures_openweathermap/utils/owm.py
+++ b/flexmeasures_openweathermap/utils/owm.py
@@ -12,7 +12,7 @@ from flexmeasures.utils.time_utils import as_server_time, get_timezone, server_n
 from flexmeasures.data.models.time_series import Sensor, TimedBelief
 from flexmeasures.data.utils import save_to_db
 
-from flexmeasures_openweathermap import DEFAULT_DEGREE_DIFFERENCE
+from flexmeasures_openweathermap import DEFAULT_MINIMAL_WEATHER_STATIONS
 
 from .locating import find_weather_sensor_by_location_or_fail
 from ..sensor_specs import mapping
@@ -80,7 +80,7 @@ def save_forecasts_in_db(
     click.echo("[FLEXMEASURES-OWM] Latitude, Longitude")
     click.echo("[FLEXMEASURES-OWM] -----------------------")
     max_degree_difference_for_nearest_weather_sensor = current_app.config.get(
-        "MINIMAL_WEATHER_STATIONS", DEFAULT_DEGREE_DIFFERENCE
+        "MINIMAL_WEATHER_STATIONS", DEFAULT_MINIMAL_WEATHER_STATIONS
     )
     for location in locations:
         click.echo("[FLEXMEASURES] %s, %s" % location)

--- a/flexmeasures_openweathermap/utils/owm.py
+++ b/flexmeasures_openweathermap/utils/owm.py
@@ -12,6 +12,8 @@ from flexmeasures.utils.time_utils import as_server_time, get_timezone, server_n
 from flexmeasures.data.models.time_series import Sensor, TimedBelief
 from flexmeasures.data.utils import save_to_db
 
+from flexmeasures_openweathermap import DEFAULT_DEGREE_DIFFERENCE
+
 from .locating import find_weather_sensor_by_location_or_fail
 from ..sensor_specs import mapping
 from .modeling import (
@@ -20,7 +22,7 @@ from .modeling import (
 )
 from .radiating import compute_irradiance
 
-    
+
 API_VERSION = "3.0"
 
 
@@ -70,7 +72,6 @@ def call_openweatherapi(
 def save_forecasts_in_db(
     api_key: str,
     locations: List[Tuple[float, float]],
-    max_degree_difference_for_nearest_weather_sensor: int = 2,
 ):
     """Process the response from OpenWeatherMap API into timed beliefs.
     Collects all forecasts for all locations and all sensors at all locations, then bulk-saves them.
@@ -78,7 +79,9 @@ def save_forecasts_in_db(
     click.echo("[FLEXMEASURES-OWM] Getting weather forecasts:")
     click.echo("[FLEXMEASURES-OWM] Latitude, Longitude")
     click.echo("[FLEXMEASURES-OWM] -----------------------")
-
+    max_degree_difference_for_nearest_weather_sensor = current_app.config.get(
+        "MINIMAL_WEATHER_STATIONS", DEFAULT_DEGREE_DIFFERENCE
+    )
     for location in locations:
         click.echo("[FLEXMEASURES] %s, %s" % location)
         weather_sensors: Dict[


### PR DESCRIPTION
The user has the capability to modify the degree search distance  for  weather stations in the `flexmeasures.cfg` file by assigning a new value to the parameter `MINIMAL_WEATHER_STATIONS`. The default value for this parameter is set to 2.

Input on naming improvement would be appreciated. 