### PR TITLE
Incorrect unit irradiance

### DIFF
--- a/flexmeasures_openweathermap/sensor_specs.py
+++ b/flexmeasures_openweathermap/sensor_specs.py
@@ -40,7 +40,7 @@ mapping = [
     dict(
         fm_sensor_name="irradiance",  # in save_forecasts_to_db, we catch this name and do the actual computation to get to the irradiance
         owm_sensor_name="clouds",
-        unit="kW/m²",
+        unit="W/m²",
         event_resolution=timedelta(minutes=60),
         attributes=weather_attributes,
     ),


### PR DESCRIPTION
In `/flexmeasures_openweathermap/sensor_specs.py` the unit for radiance is set to `kW/m²`, which (I believe) should be modified to `W/m²`. I modified the value and the results seem correct.

These are my sources:

- The SI unit of irradiance is W/m² according to [Wikipedia](https://en.wikipedia.org/wiki/Irradiance).
- [Bern's "irradiation data for every place on Earth" page](https://everywhere.solar/) has similar values to the ones imported by the plugin into flexmeasures, but with W/m² as the unit
- [ScienceDirect paper](https://www.sciencedirect.com/science/article/abs/pii/S246860692300103X): quote from the abstract: "...of 1000 W/m² (1 sun), which is the terrestrial solar spectral irradiance on a cloudless day near noon in geographic mid-latitudes..."

Before:
![image](https://github.com/SeitaBV/flexmeasures-openweathermap/assets/82306656/e7eba98a-42c6-4afc-aa3c-dd8174488837)

After:
![Untitled](https://github.com/SeitaBV/flexmeasures-openweathermap/assets/82306656/1018df8c-7e6c-4095-a86b-23707465dd3a)

Screenshot from Bern:
![image](https://github.com/SeitaBV/flexmeasures-openweathermap/assets/82306656/cf6ff237-5709-4818-b3b9-2d6d03b77e90)


(Pictures taken on different computers, explaining the different quality and size)